### PR TITLE
QCA - Initial package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,53 @@ QSP/*
 GSE/*
 *.zip
 qasm_circuits/*
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,7 @@ MANIFEST
 env/
 venv/
 ENV/
-env.bak/
-venv.bak/
+*.back
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ MANIFEST
 env/
 venv/
 ENV/
-*.back
+*.bak
 
 # mypy
 .mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qca"
+version = "0.0.1"
+dependencies = [
+    "cirq == 1.3.0.dev20231102230836",
+    "matplotlib",
+    "networkx",
+    "numpy",
+    "openfermion",
+    "openfermionpyscf",
+    "pandas",
+    "pyLIQTR >=1.0.0"
+]
+requires-python = ">=3.9"
+description = "Documentation of Applications for Quantum Computers"
+readme = "readme.md"
+license = {file = "LICENSE.txt"}
+classifiers = [
+  "Programming Language :: Python"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "setuptools.build_meta"
 name = "qca"
 version = "0.0.1"
 dependencies = [
-    "cirq == 1.3.0.dev20231102230836",
+    "cirq",
     "matplotlib",
     "networkx",
     "numpy",
     "openfermion",
     "openfermionpyscf",
     "pandas",
-    "pyLIQTR >=1.0.0"
+    "pyLIQTR == 0.3.3"
 ]
 requires-python = ">=3.9"
 description = "Documentation of Applications for Quantum Computers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 requires-python = ">=3.9"
 description = "Documentation of Applications for Quantum Computers"
-readme = "readme.md"
+readme = "README.md"
 license = {file = "LICENSE.txt"}
 classifiers = [
   "Programming Language :: Python"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-cirq
-matplotlib
-networkx
-numpy
-openfermion
-openfermionpyscf
-pandas
-pyLIQTR==0.3.3

--- a/src/qca/__init__.py
+++ b/src/qca/__init__.py
@@ -1,0 +1,1 @@
+from qca import utils

--- a/src/qca/utils/__init__.py
+++ b/src/qca/utils/__init__.py
@@ -1,0 +1,1 @@
+from . import utils

--- a/src/qca/utils/utils.py
+++ b/src/qca/utils/utils.py
@@ -1,0 +1,87 @@
+import os
+from re import findall
+from typing import Union
+from cirq import Circuit, QasmOutput
+from pyLIQTR.utils.qsp_helpers import circuit_decompose_once
+from pyLIQTR.gate_decomp.cirq_transforms import clifford_plus_t_direct_transform
+from pyLIQTR.utils.utils import count_T_gates
+
+
+def extract_number(string) -> Union[int, None]:
+    number = findall(r'\d+', string)
+    return int(number[0]) if number else None
+
+
+def count_gates(cpt_circuit) -> int:
+    count = 0
+    for moment in cpt_circuit:
+        count += len(moment)
+    return count
+
+
+def estimate_gsee(
+        circuit: Circuit,
+        outdir: str,
+        circuit_name: str = 'gse_circuit',
+        write_circuits: bool = False) -> None:
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
+    t_counts = {}
+    gate_counts = {}
+    clifford_counts = {}
+    subcircuit_counts = {}
+    subcircuit_depths = {}
+
+    outfile_data = f'{outdir}{circuit_name}_high_level.dat'
+
+    for moment in circuit:
+        for operation in moment:
+            gate_type = type(operation.gate)
+            if gate_type in subcircuit_counts:
+                subcircuit_counts[gate_type] += 1
+            else:
+                decomposed_circuit = circuit_decompose_once(
+                    circuit_decompose_once(Circuit(operation)))
+                cpt_circuit = clifford_plus_t_direct_transform(
+                    decomposed_circuit)
+
+                if write_circuits:
+                    outfile_qasm_decomposed = f'{outdir}{str(gate_type)[8:-2]}.decomposed.qasm'
+                    outfile_qasm_cpt = f'{outdir}{str(gate_type)[8:-2]}.cpt.qasm'
+                    QasmOutput(
+                        decomposed_circuit,
+                        decomposed_circuit.all_qubits()).save(outfile_qasm_decomposed)
+                    QasmOutput(cpt_circuit,
+                               cpt_circuit.all_qubits()).save(outfile_qasm_cpt)
+
+                subcircuit_counts[gate_type] = 1
+                subcircuit_depths[gate_type] = len(cpt_circuit)
+                t_counts[gate_type] = count_T_gates(cpt_circuit)
+                gate_counts[gate_type] = count_gates(cpt_circuit)
+                clifford_counts[gate_type] = gate_counts[gate_type] - \
+                    t_counts[gate_type]
+
+    total_gate_count = 0
+    total_gate_depth = 0
+    total_T_count = 0
+    total_clifford_count = 0
+    for gate in subcircuit_counts:
+        total_gate_count += subcircuit_counts[gate] * gate_counts[gate]
+        total_gate_depth += subcircuit_counts[gate] * subcircuit_depths[gate]
+        total_T_count += subcircuit_counts[gate] * t_counts[gate]
+        total_clifford_count += subcircuit_counts[gate] * clifford_counts[gate]
+    with open(outfile_data, 'w', encoding='utf-8') as file:
+        file.write(f'Logical Qubit Count: {len(circuit.all_qubits())}\n')
+        file.write(f'Total Gate Count: {total_gate_count}\n')
+        file.write(f'Total Gate Depth: {total_gate_depth}\n')
+        file.write(f'Total T Count: {total_T_count}\n')
+        file.write(f'Total Clifford Count: {total_clifford_count}\n')
+        file.write('Subcircuit Info:\n')
+        for gate in subcircuit_counts:
+            file.write(f'{gate}\n')
+            file.write(f'Subcircuit Occurrences: {subcircuit_counts[gate]}\n')
+            file.write(f'Gate count: {gate_counts[gate]}\n')
+            file.write(f'Gate depth: {subcircuit_counts[gate]}\n')
+            file.write(f'T Count: {t_counts[gate]}\n')
+            file.write(f'Clifford Count: {clifford_counts[gate]}\n')


### PR DESCRIPTION
The purpose of this PR isn't to introduce the initial packaged qc-applications deliverable, but rather to begin the structuring of the package. This PR is very bare bones and acts as an entryway to subsequent PRs. It introduces the qca module and a nested utils module with some utility functions. The goal is that for subsequent PRs that are migrating to PyLIQTR 1.0.0 to update both the utils module and their respective notebook. 

Therefore, we should expect the flow of merges to dev be the following:
    1. This PR
    2. Other PRs that are modifying their respective notebook and utils module
    3. Merge to main

The distinction to make here is that once we merge to main, it is only satisfying the first vertical slice of delivering qc-applications, i.e, migrating all notebooks to pyLIQTR1.0.0. The next vertical slice is to actually turn qc-applications into a package and perform a simple example with it. 

note that due to pyLIQTR restrictions, the requirements aren't ideal. Once pyLIQTR makes the appropriate changes, the requirements will be changed to a stable release of cirq. 