### PR TITLE
Add phase offset parameter to gsee_estimate call

### DIFF
--- a/scripts/HTSC-one-band-RE.py
+++ b/scripts/HTSC-one-band-RE.py
@@ -71,6 +71,7 @@ def main(args):
             gsee_args=gsee_args,
             init_state=init_state,
             precision_order=1,
+            phase_offset=phase_offset,
             bits_precision=bits_precision,
             circuit_name=name,
             metadata=metadata,

--- a/scripts/HTSC-two-band-RE.py
+++ b/scripts/HTSC-two-band-RE.py
@@ -75,6 +75,7 @@ def main(args):
             gsee_args=gsee_args,
             init_state=init_state,
             precision_order=1,
+            phase_offset=phase_offset,
             bits_precision=bits_precision,
             circuit_name=name,
             metadata=metadata,


### PR DESCRIPTION
Fixed issue in HTSC scripts where it would crash due to a missing argument.