### PR TITLE
Improved Complete Circuit Decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![pylint](https://img.shields.io/badge/PyLint-9.15-yellow?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-9.16-yellow?logo=python&logoColor=white)
 
 # Quantum Computing Application Specifications
 


### PR DESCRIPTION
Previously, we used cirq.decompose function to recursively decompose a circuit into their corresponding single qubit operations. Even though this worked, this generated more operations than necessary and was awfully expensive to compute. This new approach is not only faster, but results in smaller circuits as well while without sacrificing any information.  